### PR TITLE
Add FCC and HCP crystal lattices

### DIFF
--- a/mc_estim.cc
+++ b/mc_estim.cc
@@ -446,7 +446,7 @@ double GetPotEnergy_Diff(void)
             dr[id]  = (MCCoords[id][t0] - MCCoords[id][t1]);
 
             if (MINIMAGE)
-            dr[id] -= (BoxSize*rint(dr[id]/BoxSize));
+            dr[id] -= (BoxSize[id]*rint(dr[id]/BoxSize[id]));
 
             dr2    += (dr[id]*dr[id]);
          }
@@ -534,7 +534,7 @@ double GetPotEnergy_Densities(void)
             dr[id]  = (MCCoords[id][t0] - MCCoords[id][t1]);
 
             if (MINIMAGE)
-            dr[id] -= (BoxSize*rint(dr[id]/BoxSize));
+            dr[id] -= (BoxSize[id]*rint(dr[id]/BoxSize[id]));
 
             dr2    += (dr[id]*dr[id]);
          }
@@ -723,7 +723,7 @@ double GetPotEnergy(void)
             dr[id]  = (MCCoords[id][t0] - MCCoords[id][t1]);
 
             if (MINIMAGE)
-            dr[id] -= (BoxSize*rint(dr[id]/BoxSize));
+            dr[id] -= (BoxSize[id]*rint(dr[id]/BoxSize[id]));
 
             dr2    += (dr[id]*dr[id]);
          }
@@ -914,7 +914,7 @@ double GetKinEnergy(void)
              double dr = MCCoords[dim][t0] - MCCoords[dim][t1];
 
              if (MINIMAGE)
-             dr  -= (BoxSize*rint(dr/BoxSize));
+             dr  -= (BoxSize[dim]*rint(dr/BoxSize[dim]));
 
              sum += (dr*dr);
           }    
@@ -1337,7 +1337,9 @@ void SaveDensities1D(const char fname [], double acount)
 
   fid.open(fdens.c_str(),ios::out); io_setout(fid);
 
-  double volume = pow(BoxSize,(double)NDIM);     // 3D only  
+  double volume = 1.0;
+  for (int id=0;id<NDIM;id++)
+  volume *= BoxSize[id];
 
   double norm0  = 2.0*M_PI*_delta_radius*acount  // normalization factor for 
                 *(double)(NumbTimes)/volume;     // radial distribution functions 

--- a/mc_input.cc
+++ b/mc_input.cc
@@ -48,6 +48,9 @@ const char IO_ROTDENSI[]       = "ROTDENSI";
 
 const char IO_WORM[]           = "WORM";
 const char IO_MINIMAGE[]       = "MINIMAGE";
+const char IO_CRYSTAL[]        = "CRYSTAL";
+const char IO_FCC[]            = "FCC";
+const char IO_HCP[]            = "HCP";
 
 const char IO_MCSKIP_RATIO[]   = "MCSKIP_RATIO";
 const char IO_MCSKIP_TOTAL[]   = "MCSKIP_TOTAL"; 
@@ -84,6 +87,7 @@ void IOReadParams(const char in_file[],int & mc_status)
    IMPURITY = false;
    WORM     = false;
    MINIMAGE = false;
+   CRYSTAL  = false;
 
    ROTATION = false;
 
@@ -101,6 +105,7 @@ void IOReadParams(const char in_file[],int & mc_status)
    double  _rot_step;      // step for sampling the rotational degrees of freedom
    string _srot_type;      // the molecule type to sample the rotational degrees of freedom
    string _srot_dens;      // the file name with the rotational density matrix
+   string crytype;         // type of crystal (FCC or HCP)
 
    InitMCCoords = 0;
 
@@ -295,6 +300,23 @@ void IOReadParams(const char in_file[],int & mc_status)
         MINIMAGE = true;
      }
      else
+     if (params==IO_CRYSTAL)
+     {
+        CRYSTAL = true;
+        if (NDIM != 3)
+        nrerror(_proc_,"Crystal must be in 3 dimensions");
+        inf >> crytype;
+        if (crytype==IO_FCC)
+           FCC = 1;
+        else if (crytype==IO_HCP)
+           HCP = 1;
+        else
+           nrerror(_proc_,"Unknown crystal type");
+        inf >> N1d[0] >> N1d[1] >> N1d[2];
+        if (NUMB_ATOMS != (N1d[0]*N1d[1]*N1d[2]*4))
+        nrerror(_proc_,"NUMB_ATOMS = N1d1*N1d2*N1d3*4 with CRYSTAL");
+     }
+     else
      if (params==IO_READMCCOORDS)
      {
         InitMCCoords = 1;
@@ -442,6 +464,12 @@ void IOReadParams(const char in_file[],int & mc_status)
    nrerror(_proc_,"ISPHER = 1 is not compatible with ROTATION");
 
    cout << "NONLINEAR DOPANT SPHERICAL TREATMENT: "<<ISPHER<<endl;
+
+   if(CRYSTAL)
+   {
+      cout<<"Crystal type: "<<crytype<<endl;
+      cout<<"Number of unit cells along each side: "<<N1d[0]<<" "<<N1d[1]<<" "<<N1d[2]<<endl;
+   }
 
    cout << "Number of Slices = " << NumbTimes << endl;
    cout << "Number of Passes = " << NumberOfMCPasses << endl;

--- a/mc_piqmc.cc
+++ b/mc_piqmc.cc
@@ -1237,7 +1237,7 @@ double PotEnergy(int atom0, double **pos)
              dr[id]  = (pos[id][t0] - MCCoords[id][t1]);
             
              if (MINIMAGE)
-             dr[id] -= (BoxSize*rint(dr[id]/BoxSize));
+             dr[id] -= (BoxSize[id]*rint(dr[id]/BoxSize[id]));
 
              dr2    += (dr[id]*dr[id]);
           }
@@ -1830,7 +1830,7 @@ double PotEnergy(int atom0, double **pos, int it)
            dr[id]  = (pos[id][t0] - MCCoords[id][t1]);
 
            if (MINIMAGE)
-           dr[id] -= (BoxSize*rint(dr[id]/BoxSize));
+           dr[id] -= (BoxSize[id]*rint(dr[id]/BoxSize[id]));
  
            dr2    += (dr[id]*dr[id]);
         }
@@ -2013,7 +2013,7 @@ double PotRotEnergy(int atom0,double ** cosine,int it)
             if (MINIMAGE)
             {
             cout << "MIN IMAGE for orient pot" << endl; exit(0);
-            dr[id] -= (BoxSize*rint(dr[id]/BoxSize));
+            dr[id] -= (BoxSize[id]*rint(dr[id]/BoxSize[id]));
             }
  
             dr2    += (dr[id]*dr[id]);

--- a/mc_qworm.cc
+++ b/mc_qworm.cc
@@ -138,7 +138,7 @@ double qw_open_prob(int segm)
       double dr = MCCoords[id][pt0] - MCCoords[id][pt1];
 
       if (MINIMAGE)
-      dr  -= (BoxSize*rint(dr/BoxSize));
+      dr  -= (BoxSize[id]*rint(dr/BoxSize[id]));
 
       kin += (dr*dr); 
    }
@@ -211,7 +211,7 @@ void  qworm_close  (void)
       double dr = MCCoords[id][pt0] - MCCoords[id][pt1];
  
       if (MINIMAGE)
-      dr  -= (BoxSize*rint(dr/BoxSize));
+      dr  -= (BoxSize[id]*rint(dr/BoxSize[id]));
 
       kin += (dr*dr); 
    }
@@ -612,7 +612,7 @@ int get_ptable(int atomw, int pt0, int pt1, int segm, int t1)
            double dx = MCCoords[id][itw] - MCCoords[id][it1];  // exchange
 
            if (MINIMAGE)
-           dx  -= (BoxSize*rint(dx/BoxSize));
+           dx  -= (BoxSize[id]*rint(dx/BoxSize[id]));
 
            dr2 += (dx*dx);
         }

--- a/mc_qworm.h
+++ b/mc_qworm.h
@@ -29,7 +29,7 @@ void MCWormMove(void);
 
 bool WorldLine(int, int);            
 
-typedef struct TPathWorm
+struct TPathWorm
 {
    char    stype[MAX_STRING_LENGTH]; // type of atoms/molecules
    int     type;                     // atoms type to apply the worm algorithm (He)

--- a/mc_randg.cc
+++ b/mc_randg.cc
@@ -36,7 +36,7 @@ void RandomFree(void) // free memory used by sprng
 void RandomIO(int tstatus, const char file_name[]) // check point for sprng streams
 {
   const char *_proc_=__func__;    // "RandIO()";
-  char *fop="r";                  // file operation
+  const char *fop="r";            // file operation
 
   switch (tstatus)
   {
@@ -73,8 +73,10 @@ void RandomIO(int tstatus, const char file_name[]) // check point for sprng stre
          for (int ip=0;ip<MAXGENS;ip++)
          {
             free_sprng(STREAM[ip]);
-            fread(&size,1,sizeof(int),fp);
-            fread(buffer,1,size,fp);
+            if (fread(&size,1,sizeof(int),fp) != sizeof(int))
+            nrerror(_proc_,"Failed to read stream size");
+            if (fread(buffer,1,size,fp) != size)
+            nrerror(_proc_,"Failed to read stream data");
             STREAM[ip] = unpack_sprng(buffer);
          }
          break;

--- a/mc_setup.h
+++ b/mc_setup.h
@@ -58,7 +58,7 @@ extern int    NumbRotLim; // limit of number of one type of rotors
 extern int NumbAtoms; // total number of atoms and molecules
 extern int NumbTypes; // Number of particles' types
 
-typedef struct TParticle
+struct TParticle
 {
    int    numb;                    // number of atoms/molecule of this type  
    double mass;                    // mass of atom/molecule
@@ -192,7 +192,7 @@ void MCMemFree(void);  // free memory
 
 //------------ MC SYSTEM OF UNITS --------------------------
 
-typedef struct TSystemOfUnits
+struct TSystemOfUnits
 {
    double mass;        
    double energy;       

--- a/mc_setup.h
+++ b/mc_setup.h
@@ -12,6 +12,10 @@ extern bool    WORM;              // use the worm algorithm
 
 extern bool    IMPURITY;     // set true if there is a molecule in the system
 extern bool    MINIMAGE;     // set true to apply minimum image convention 
+extern bool    CRYSTAL;      // set true to use crystal geometry
+//Add by Lecheng Wang, June 2014
+extern bool    FCC;          // set true if CRYSTAL and FCC structure
+extern bool    HCP;          // set true if CRYSTAL and HCP structure
 
 extern bool    BOSONS;       // true if there're bosons in the system
 extern int     BSTYPE;       // atom type for bosons
@@ -39,7 +43,8 @@ extern int     NUMB_MOLCTYPES; // total number of molecules types
 extern int     NDIM;
 extern double  Temperature;
 extern double  Density;
-extern double  BoxSize;
+extern double *BoxSize;
+extern int     N1d[3];
 
 extern double  MCBeta;     // imaginary time step 
 extern double  MCTau;      // imaginary time step 


### PR DESCRIPTION
I took some of Lecheng's old code for crystal lattices and updated it to work with the new MoRiBS. In the process, I made it slightly more general. Before, the `MINIMAGE` configuration keyword was repurposed:
```
MINIMAGE 3.76 HCP 4 3 3
```
Now, the new `CRYSTAL` keyword is orthogonal to `MINIMAGE` and can be used with or without it:
```
CRYSTAL HCP 4 3 3
```
The nearest neighbor distance is not explicit anymore, but is instead inferred from the density.